### PR TITLE
Include get-ssl-certificate package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/Heholord/FalconStats#readme",
   "dependencies": {
-    "ansi-styles": "^3.2.1"
+    "ansi-styles": "^3.2.1",
+    "get-ssl-certificate": "^2.1.2"
   }
 }


### PR DESCRIPTION
The get-ssl-certificate package wasn't installed by npm, but appears to be required for ssl.js