### PR TITLE
Column alignment

### DIFF
--- a/scripts/discspace.sh
+++ b/scripts/discspace.sh
@@ -3,17 +3,18 @@
 myDir=$(dirname "$0")
 source "$myDir/config.sh"
 
-clear="\e[39\e[0m"
-dim="\e[2m"
+clear=$(tput sgr0)
+dim=$(tput dim)
 
 for point in ${mountpoints}; do
     line=$(df -hl "${point}")
     usagePercent=$(echo "$line"|tail -n1|awk '{print $5;}'|sed 's/%//')
     usedBarWidth=$((($usagePercent*$barWidth)/100))
     barContent=""
-    color="\e[32m"
     if [ "${usagePercent}" -ge "${maxDiscUsage}" ]; then
-        color="\e[31m"
+        color=$(tput setaf 1)
+    else
+        color=$(tput setaf 2)
     fi
     barContent="${color}"
     for sep in $(seq 1 $usedBarWidth); do

--- a/scripts/discspace.sh
+++ b/scripts/discspace.sh
@@ -1,35 +1,29 @@
 #!/bin/bash
 
-myDir=$(dirname "$0")
-source "$myDir/config.sh"
+source "$(dirname "$0")/config.sh"
 
 clear=$(tput sgr0)
 dim=$(tput dim)
 
+df_info="$(df -hl)"
+echo "${df_info}" | head -n 1
+
 for point in ${mountpoints}; do
-    line=$(df -hl "${point}")
+    line=$(echo "${df_info}" | grep $point)
     usagePercent=$(echo "$line"|tail -n1|awk '{print $5;}'|sed 's/%//')
     usedBarWidth=$((($usagePercent*$barWidth)/100))
-    barContent=""
-    if [ "${usagePercent}" -ge "${maxDiscUsage}" ]; then
-        color=$(tput setaf 1)
-    else
-        color=$(tput setaf 2)
-    fi
-    barContent="${color}"
+
+    bar=$(tput setaf 2)
+    [ "${usagePercent}" -ge "${maxDiscUsage}" ] && bar=$(tput setaf 1)
+
     for sep in $(seq 1 $usedBarWidth); do
-        barContent="${barContent}="
+        bar="$bar="
     done
-    barContent="${barContent}${clear}${dim}"
+    bar="$bar$clear$dim"
     for sep in $(seq 1 $(($barWidth-$usedBarWidth))); do
-        barContent="${barContent}="
+        bar="$bar="
     done
-    bar="[${barContent}${clear}]"
-    if [ "${titeled}" == "" ]; then
-        echo "${line}"
-        titeled="1"
-    else
-        echo "${line}"|tail -n1
-    fi
-    echo -e "${bar}"
+
+    echo "${line}"|tail -n1
+    echo -e "[$bar$clear]"
 done


### PR DESCRIPTION
In the original script, columns would be misaligned because `df` is called several times on different mount points, so its spacing would be different when filesystem names differ in length.

![image](https://user-images.githubusercontent.com/20404439/43336293-9779d55e-919e-11e8-9cfb-3e5fe88c6750.png)

I refactored the code to call `df` only once. `$line` is extracted using `grep`. 

- `titeled="1"` was a filthy hack
- column spacing issue fixed
- This gives flexibility because you can specify either filesystem or mount point, but **specifying `/` as a mount point won't work anymore**.
