### PR TITLE
fix broken link to config.json file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For interactive configuration run
 node init.js
 ```
 
-You can always view or edit your config in [scripts/config.json](config.json)
+You can always view or edit your config in [scripts/config.json](scripts/config.json)
 
 ## Testrun your motd
 


### PR DESCRIPTION
Line 50 of the README.md file, 
the link is written as "[scripts/config.json](config.json)" and that file don't exists, so I replaced to "[scripts/config.json](scripts/config.json)" to reflect to the actual file.

Great work on this project! 🎉👏